### PR TITLE
response.result == null response is resolved as INTERNAL_ERROR

### DIFF
--- a/lib/jsonrpc.js
+++ b/lib/jsonrpc.js
@@ -138,7 +138,8 @@ module.exports = (function(){
 					var response = {}, code, message, data;
 
 					// .result means it's a success
-					if ( responseObj.result ) {
+					// .result == null is a valid response
+					if ( responseObj['result'] !== undefined ) {
 						response = {
 							jsonrpc: '2.0',
 							id: id,


### PR DESCRIPTION
though spec does not say it is invalid, it just says that result MUST be present and 'null' imho means that it is present (when opposed to undefined), just server does not have much meaningful to send back:)
